### PR TITLE
Append Slash to Directory Listing

### DIFF
--- a/server/web_apps/file/src/modules/file_browser.js
+++ b/server/web_apps/file/src/modules/file_browser.js
@@ -179,10 +179,7 @@ export class FileBrowser extends ChunkFormFiles {
 
                 if(reg && directories[i].name.search(reg) === -1){ continue }
 
-                let abs_path = `/${directories[i].name}`;
-                if(this.props.getCwd() !== '/'){
-                    abs_path = `${this.props.getCwd()}${abs_path}`;
-                }
+                let abs_path = `${this.props.getCwd()}${directories[i].name}/`;
 
                 dirEles.push(
                     <DirItem
@@ -404,8 +401,7 @@ export class FileBrowser extends ChunkFormFiles {
                             disabled={this.props.getCwd() === '/'}
                             onClick={(e) => {
                                 e.preventDefault();
-                                let s = this.props.getCwd().split('/');
-                                s = s.slice(0,s.length-1).join('/')
+                                let s = [...this.props.getCwd().matchAll('.*?/')].slice(0,-1).join('');
                                 this.props.inspectDir(s !== '' ? s : '/', true);
                             }}
                         >


### PR DESCRIPTION
Closes #4

Ensures that all directories end with "/" to fix a file upload bug where the missing slash caused for some unintended behavior.

Also slightly updates the Back button logic to account for the new slash, this time using lazy regex with `matchAll`.